### PR TITLE
bug(backend): prevent duplicate emails

### DIFF
--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -53,7 +53,8 @@ class AccountAdapter(DefaultAccountAdapter):
         # is caught.  So, if a check fails I just raise an ImmediateHttpResponse w/ the correct response.
 
         if app_settings.ASTROSAT_USERS_REQUIRE_VERIFICATION and not user.is_verified:
-            send_email_confirmation(request, user)
+            # don't automatically send another verification email
+            # send_email_confirmation(request, user)
             response = self.respond_email_verification_sent(request, user)
             raise ImmediateHttpResponse(response)
 

--- a/astrosat_users/admin/admin_users.py
+++ b/astrosat_users/admin/admin_users.py
@@ -55,7 +55,7 @@ class UserAdmin(auth_admin.UserAdmin):
 
     form = UserAdminChangeForm
     add_form = UserAdminCreationForm
-    actions = (logout_all,)
+    actions = (logout_all, verify)
     fieldsets = (
         (
             "User",

--- a/astrosat_users/admin/admin_users.py
+++ b/astrosat_users/admin/admin_users.py
@@ -42,6 +42,14 @@ def logout_all(model_admin, request, queryset):
 logout_all.short_description = "Logs the selected users out of all active sessions"
 
 
+def verify(model_admin, request, queryset):
+    for obj in queryset:
+        obj.verify()
+
+
+verify.short_description = "Sets the selected users' primary email address to 'verified'"
+
+
 @admin.register(User)
 class UserAdmin(auth_admin.UserAdmin):
 

--- a/astrosat_users/serializers/__init__.py
+++ b/astrosat_users/serializers/__init__.py
@@ -1,5 +1,6 @@
 from .serializers_auth import (
     RegisterSerializer,
+    SendEmailVerificationSerializer,
     LoginSerializer,
     PasswordChangeSerializer,
     PasswordResetSerializer,

--- a/astrosat_users/urls.py
+++ b/astrosat_users/urls.py
@@ -26,6 +26,7 @@ from .views import (
     LoginView,
     LogoutView,
     RegisterView,
+    SendEmailVerificationView,
     VerifyEmailView,
     PasswordChangeView,
     PasswordResetView,
@@ -61,6 +62,7 @@ api_urlpatterns = [
     path("authentication/password/verify-reset/", PasswordResetConfirmView.as_view(), name="rest_password_reset_confirm"),
     path("authentication/registration/", RegisterView.as_view(), name="rest_register"),
     path("authentication/registration/verify-email/", VerifyEmailView.as_view(), name="rest_verify_email",),
+    path("authentication/send-email-verification/", SendEmailVerificationView.as_view(), name="rest_send_email_verification"),
 ]
 
 

--- a/astrosat_users/views/__init__.py
+++ b/astrosat_users/views/__init__.py
@@ -18,4 +18,5 @@ from .views_api_auth import (
     PasswordResetConfirmView,
     RegisterView,
     VerifyEmailView,
+    SendEmailVerificationView,
 )


### PR DESCRIPTION
After registration, the code tried to log a user in.  An unverified user
would not be able to login.  It would automatically send a new
verification email in that situation.  But, it would have just sent a
verification email as part of the registration process.

To address this, I stopped automatically sending a new verification
email during login.  And I added a new endpoint for sending a new
verification email.  In order for that to work, you need to pass it a
valid email address.  So, the error responses for unverified (and
unapproved) users now includes some minimal information about the user.

I also added a verify action to the user admin.

IssueID #27