### PR TITLE
added a generate-token endpoint

### DIFF
--- a/astrosat_users/checks.py
+++ b/astrosat_users/checks.py
@@ -18,7 +18,6 @@ APP_DEPENDENCIES = [
     "rest_auth",
     "rest_auth.registration",
     "knox",
-    # "rest_framework.authtoken",
 ]
 
 

--- a/astrosat_users/urls.py
+++ b/astrosat_users/urls.py
@@ -9,7 +9,6 @@ from rest_framework.routers import SimpleRouter
 from allauth.urls import urlpatterns as allauth_urlpatterns
 
 # Backend views...
-
 from .views import (
     DisabledView,
     DisapprovedView,
@@ -35,6 +34,11 @@ from .views import (
     UserViewSet,
     UserRoleViewSet,
     UserPermissionViewSet,
+)
+
+# API views that still authenticate w/ backend...
+from .views import (
+    token_view,
 )
 
 from astrosat.decorators import conditional_redirect
@@ -64,6 +68,9 @@ api_urlpatterns = [
     path("authentication/registration/", RegisterView.as_view(), name="rest_register"),
     path("authentication/registration/verify-email/", VerifyEmailView.as_view(), name="rest_verify_email"),
     path("authentication/send-email-verification/", SendEmailVerificationView.as_view(), name="rest_send_email_verification"),
+    # a "special" api_urlpattern that authenticates using django-allauth NOT django-rest-auth
+    path("token", token_view, name="token"),
+
 ]
 
 

--- a/astrosat_users/views/__init__.py
+++ b/astrosat_users/views/__init__.py
@@ -20,3 +20,4 @@ from .views_api_auth import (
     VerifyEmailView,
     SendEmailVerificationView,
 )
+from .views_tokens import token_view

--- a/astrosat_users/views/views_tokens.py
+++ b/astrosat_users/views/views_tokens.py
@@ -1,0 +1,38 @@
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.exceptions import APIException
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from rest_auth.models import TokenModel
+from rest_auth.app_settings import TokenSerializer, create_token
+
+from astrosat_users.conf import app_settings
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+# notice how  this uses the standard Django SessionAuthentication instead of the DRF's TokenAuthentication
+@authentication_classes([SessionAuthentication])
+def token_view(request):
+    """
+    Used to generate a token for the API from the Backend;
+    Given a POST from a user that logged in via the Backend
+    creates a new KnoxToken and returns the token key.
+    """
+    if not app_settings.ASTROSAT_USERS_ENABLE_BACKEND_ACCESS:
+        raise APIException(
+            "token_view can only be called when ASTROSAT_USERS_ENABLE_BACKEND_ACCESS is set to 'True'"
+        )
+
+    try:
+        _, token_key = create_token(TokenModel, request.user, TokenSerializer)
+    except Exception as e:
+        raise APIException(e)
+
+    return Response({"token": token_key})


### PR DESCRIPTION
Now that the API uses `TokenAuthentication`, a token must be passed w/ most requests.   

However, the backend still use `SessionAuthentication` for the standard Django workflow.  

I have therefore added an API endpoint for those clients where login/registration is done via the backend (ie: Django forms/templates) which generates a token to use for pure API calls.