### PR TITLE
feat(backend): support for custom profile serializers

### DIFF
--- a/astrosat_users/models/models_profiles.py
+++ b/astrosat_users/models/models_profiles.py
@@ -6,6 +6,7 @@ from django.db.models.fields.related import OneToOneField
 from django.forms import ModelChoiceField
 
 
+# TODO: MAKE THIS INHERIT FROM dict LIKE THE ORBIS AdapterRegistry
 PROFILES = {}
 
 
@@ -15,6 +16,20 @@ def get_profile_qs():
     ]
     # clever way of combining multiple querysets
     return chain(*profile_querysets)
+
+
+# TODO: MOVE THIS FN TO django-astrosat-core
+def reflect_class_from_name(class_name):
+    """
+    serializer_class is passed as a string to the field below;
+    (it _has_ to do this to avoid circular dependencies)
+    this fn takes that string and returns the actual class
+    """
+    class_name_parts = class_name.split(".")
+    reflected_class = __import__(".".join(class_name_parts[:-1]))
+    for part in class_name_parts[1:]:
+        reflected_class = getattr(reflected_class, part)
+    return reflected_class
 
 
 class UserProfileField(OneToOneField):
@@ -33,11 +48,10 @@ class UserProfileField(OneToOneField):
     (keyed by "related_name").  All possible profile classess are stored in the PROFILES dictionary above.
     """
 
-    # TODO; ADD A "serializer" KWARG THAT DEFAULTS TO None TO HELP W/ SERIALIZATION
-
     def __init__(self, *args, **kwargs):
 
         self.key = kwargs.get("related_name", None)
+        self.serializer_class = kwargs.pop("serializer_class", None)
         assert (
             self.key is not None
         ), "'related_name' must be specified for UserProfileField."
@@ -53,17 +67,28 @@ class UserProfileField(OneToOneField):
 
     def contribute_to_class(self, cls, name, **kwargs):
         """
-        Adds the key to the profile class.
         Updates the PROFILES dictionary w/ this class.
+        Adds the key to the profile class.
+        And sets the serializer class (either a custom one passed in __init__
+        or the generic one).
         """
 
         assert name == "user", "UserProfileField must be called 'user'."
 
         super().contribute_to_class(cls, name, **kwargs)
 
+        PROFILES[self.key] = cls
         setattr(cls, "key", self.key)
 
-        PROFILES[self.key] = cls
+        # using lambdas to pass a fn which gets the serializer on-demand
+        # instead of trying to get it inline here (which could result in circular dependencies)
+        if self.serializer_class is not None:
+            get_serializer_fn = lambda *args: reflect_class_from_name(self.serializer_class)
+        else:
+            get_serializer_fn = lambda *args: reflect_class_from_name(
+                "astrosat_users.serializers.serializers_users.GenericProfileSerializer"
+            )().wrap_profile(cls)
+        setattr(cls, "get_serializer_class", get_serializer_fn)
 
     def contribute_to_related_class(self, cls, related):
         """

--- a/example/example/models.py
+++ b/example/example/models.py
@@ -10,7 +10,7 @@ class ExampleProfile(models.Model):
     A silly user profile, just for testing.
     """
 
-    user = UserProfileField(related_name="example_profile")
+    user = UserProfileField(related_name="example_profile", serializer_class="example.serializers.ExampleProfileSerializer")
 
     # some silly fields for playing w/ profiles...
     age = models.IntegerField(blank=True, null=True, help_text=_("Age in years."))

--- a/example/example/serializers.py
+++ b/example/example/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+
+from example.models import ExampleProfile
+
+
+class ExampleProfileSerializer(serializers.ModelSerializer):
+    """
+    A silly serializer, just for testing.
+    """
+    class Meta:
+        model = ExampleProfile
+        fields = ("age", "height", "weight", "body_mass_index",)


### PR DESCRIPTION
Added a `serializer_class` kwarg for `UserProfileField` that takes the name of a custom serializer to use.  The corresponding `UserProfile` is given a `get_serializer_class` fn that returns either that serializer or else the `GenericProfileSerializer` to use in serialization/deserialization.

IssueID #14