### PR TITLE
Customer user notifications

### DIFF
--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -249,12 +249,14 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
 
         url = self.get_password_confirmation_url(self.request, user, token_key)
 
-        context = {
+        template_prefix = kwargs.get("template_prefix", "account/email/password_reset_key")
+        context = kwargs.get("context", {})
+        context.update({
             "current_site": get_current_site(self.request),
             "user": user,
             "password_reset_url": url,
             "request": self.request,
-        }
+        })
 
         if (
             allauth_app_settings.AUTHENTICATION_METHOD
@@ -262,7 +264,7 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
         ):
             context["username"] = user_username(user)
 
-        self.send_mail("account/email/password_reset_key", email, context)
+        self.send_mail(template_prefix, email, context)
 
     def set_password(self, user, password):
         user.set_password(password)

--- a/astrosat_users/models/models_customers.py
+++ b/astrosat_users/models/models_customers.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -143,6 +144,10 @@ class CustomerUser(models.Model):
 
     def __str__(self):
         return f"{self.customer}: {self.user}"
+
+    def clean(self):
+        if self.pk is None and self.user in self.customer.users.all():
+            raise ValidationError("User is already a member of Customer.")
 
     def invite(self):
         # TODO: for now I'm just setting the date, need to actually do the invite

--- a/astrosat_users/templates/astrosat_users/email/customer_user_password_reset_key_message.txt
+++ b/astrosat_users/templates/astrosat_users/email/customer_user_password_reset_key_message.txt
@@ -1,0 +1,19 @@
+{# used for resetting the password in the context of a user created by a customer manager #}
+
+{% load i18n %}
+
+{% autoescape off %}
+
+  Hi, you have been invited by an Administrator of {{ customer.title }} to have access to {{ customer.title }}'s ORBIS Account.
+
+  Please follow the link below to create a User Account and Password.
+
+{{ password_reset_url }}
+
+{% if username %}
+  {% blocktrans %}
+    In case you forgot, your username is {{ username }}.
+  {% endblocktrans %}
+{% endif %}
+
+{% endautoescape %}

--- a/astrosat_users/templates/astrosat_users/email/customer_user_password_reset_key_subject.txt
+++ b/astrosat_users/templates/astrosat_users/email/customer_user_password_reset_key_subject.txt
@@ -1,0 +1,11 @@
+{# used for resetting the password in the context of a user created by a customer manager #}
+
+{% load i18n %}
+
+{% autoescape off %}
+
+{% blocktrans %}
+  Welcome to ORBIS - Please sign in
+{% endblocktrans %}
+
+{% endautoescape %}


### PR DESCRIPTION
* when a new CustomerUser is created, do not automatically send them an email asking them to verify their email address - instead, send them an email asking them to reset their password
* added custom templates for the above email (rather than the built-in reset password template used in other situations)
* ensured a user cannot be added multiple times to the same customer
* when a CustomerUser resets their password, set them to "ACTIVE" and verify their email address (if it hasn't already been verified)