### PR TITLE
feat(backend): refactored password validators 

### DIFF
--- a/astrosat_users/validators.py
+++ b/astrosat_users/validators.py
@@ -4,6 +4,8 @@ from django.utils.deconstruct import deconstructible
 
 from zxcvbn import zxcvbn
 
+from astrosat_users.conf import app_settings as astrosat_users_settings
+
 
 #########################
 # user image validation #
@@ -47,9 +49,9 @@ class LengthPasswordValidator:
     Validates the password length is inside a range.
     """
 
-    def __init__(self, min_length=8, max_length=255):
+    def __init__(self, min_length=astrosat_users_settings.PASSWORD_MIN_LENGTH, max_length=astrosat_users_settings.PASSWORD_MAX_LENGTH):
         assert (
-            max_length > min_length and min_length >= 1 and max_length <= 255
+            max_length > min_length and min_length > 0 and max_length > 0
         ), "Invalid LengthPasswordValidator"
         self.min_length = min_length
         self.max_length = max_length
@@ -85,8 +87,8 @@ class StrengthPasswordValidator:
         4 # very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
     """
 
-    def __init__(self, strength=2):
-        assert 0 <= strength <= 4, "Invaid StrongPasswordValidator strength."
+    def __init__(self, strength=astrosat_users_settings.PASSWORD_STRENGTH):
+        assert 0 <= strength <= 4, "Invalid StrongPasswordValidator strength."
         self.strength = strength
 
     def validate(self, password, user=None):

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -12,8 +12,6 @@ from django.utils.html import escape
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
-from astrosat_users.conf import app_settings as astrosat_users_settings
-
 
 env = environ.Env()
 
@@ -217,15 +215,10 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
     {
-        "NAME": "astrosat_users.validators.LengthPasswordValidator",
-        "OPTIONS": {
-            "min_length": astrosat_users_settings.PASSWORD_MIN_LENGTH,
-            "max_length": astrosat_users_settings.PASSWORD_MAX_LENGTH,
-        },
+        "NAME": "astrosat_users.validators.LengthPasswordValidator"
     },
     {
-        "NAME": "astrosat_users.validators.StrengthPasswordValidator",
-        "OPTIONS": {"strength": astrosat_users_settings.PASSWORD_STRENGTH},
+        "NAME": "astrosat_users.validators.StrengthPasswordValidator"
     },
 ]
 


### PR DESCRIPTION
Refactored password validators to use dynamic settings by default;
otherwise I would have to reference astrosat_users dynamic settings in
the project settings which could potentially cause circular dependency
issues.  Now I only need to add options to the password validators if I
_don't_ want to use the default dynamic settings.