### PR TITLE
feat(backend): dont wrap faker

### DIFF
--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -141,7 +141,11 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
         else:
             path = reverse("account_confirm_email", args=[emailconfirmation.key])
 
-        url = urljoin(request.META['HTTP_ORIGIN'], path)
+        if self.is_api and "HTTP_ORIGIN" in request.META:
+            # request originates from a client on a different domain...
+            url = urljoin(request.META['HTTP_ORIGIN'], path)
+        else:
+            url = build_absolute_uri(request, path)
         return url
 
     def get_password_confirmation_url(self, request, user, token=None):
@@ -164,7 +168,11 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
                 kwargs={"key": token_key, "uidb36": user_pk_to_url_str(user)},
             )
 
-        url = urljoin(request.META['HTTP_ORIGIN'], path)
+        if self.is_api and "HTTP_ORIGIN" in request.META:
+            # request originates from a client on a different domain...
+            url = urljoin(request.META['HTTP_ORIGIN'], path)
+        else:
+            url = build_absolute_uri(request, path)
         return url
 
     def login(self, request, user):

--- a/astrosat_users/tests/utils.py
+++ b/astrosat_users/tests/utils.py
@@ -1,10 +1,11 @@
-from factory.faker import Faker as FactoryFaker
+from faker import Faker
 
 from allauth.account.adapter import get_adapter
 
 from dj_rest_auth.models import TokenModel
 from dj_rest_auth.app_settings import TokenSerializer, create_token
 
+fake = Faker()
 
 def generate_password(**kwargs):
     """
@@ -19,8 +20,7 @@ def generate_password(**kwargs):
     }
     password_kwargs.update(kwargs)
     assert password_kwargs["length"] >= 4  # faker will break if the pwd is _too_ short
-    password_faker = FactoryFaker("password", **password_kwargs)
-    return password_faker.generate(extra_kwargs={})
+    return fake.password(**password_kwargs)
 
 
 def get_adapter_from_response(response):


### PR DESCRIPTION
Updated `generate_password` utility function to no longer call **factoryboy's** faker wrapper `generate` fn b/c that is intended to be _private_ method.  Instead, using **faker** itself.

Also updated the recent changes to `get_password_confirmation_email` and `get_email_confirmation_email` to not _always_ assume that the client/server are on different domains.