### PR TITLE
feat(backend): make customer createable via API

### DIFF
--- a/astrosat_users/tests/factories.py
+++ b/astrosat_users/tests/factories.py
@@ -13,6 +13,7 @@ from astrosat.tests.utils import optional_declaration
 
 from allauth.account.models import EmailAddress
 from astrosat_users.models import User, UserRole, UserPermission, Customer
+from astrosat_users.models.models_customers import CustomerType
 from astrosat_users.tests.utils import *
 
 
@@ -124,7 +125,7 @@ class CustomerFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Customer
 
-    # customer_type = models.CharField(max_length=64, choices=CustomerType.choices, default=CustomerType.MULTIPLE)
+    customer_type = CustomerType.MULTIPLE
 
     name = factory.LazyAttributeSequence(lambda o, n: f"{slugify(o.title)}-{n}")
     title = FactoryFaker("pretty_sentence", nb_words=2)

--- a/astrosat_users/urls.py
+++ b/astrosat_users/urls.py
@@ -26,8 +26,8 @@ from .views import (
     VerifyEmailView,
     SendEmailVerificationView,
     UserViewSet,
-    CustomerListView,
-    CustomerDetailView,
+    CustomerCreateView,
+    CustomerUpdateView,
     CustomerUserListView,
     CustomerUserDetailView,
     CustomerUserInviteView,
@@ -47,10 +47,10 @@ api_router.register("users", UserViewSet, basename="users")
 api_urlpatterns = [
     path("", include(api_router.urls)),
     path(
-        "customers/", CustomerListView.as_view(), name="customers-list"
+        "customers/", CustomerCreateView.as_view(), name="customers-list"
     ),
     path(
-        "customers/<slug:customer_id>/", CustomerDetailView.as_view(), name="customers-detail"
+        "customers/<slug:customer_id>/", CustomerUpdateView.as_view(), name="customers-detail"
     ),
     path(
         "customers/<slug:customer_id>/users/",

--- a/astrosat_users/urls.py
+++ b/astrosat_users/urls.py
@@ -26,6 +26,7 @@ from .views import (
     VerifyEmailView,
     SendEmailVerificationView,
     UserViewSet,
+    CustomerListView,
     CustomerDetailView,
     CustomerUserListView,
     CustomerUserDetailView,
@@ -45,6 +46,9 @@ api_router = SimpleRouter()
 api_router.register("users", UserViewSet, basename="users")
 api_urlpatterns = [
     path("", include(api_router.urls)),
+    path(
+        "customers/", CustomerListView.as_view(), name="customers-list"
+    ),
     path(
         "customers/<slug:customer_id>/", CustomerDetailView.as_view(), name="customers-detail"
     ),

--- a/astrosat_users/views/__init__.py
+++ b/astrosat_users/views/__init__.py
@@ -10,6 +10,7 @@ from .views_auth import (
     SendEmailVerificationView,
 )
 from .views_customers import (
+    CustomerListView,
     CustomerDetailView,
     CustomerUserListView,
     CustomerUserDetailView,

--- a/astrosat_users/views/__init__.py
+++ b/astrosat_users/views/__init__.py
@@ -10,8 +10,8 @@ from .views_auth import (
     SendEmailVerificationView,
 )
 from .views_customers import (
-    CustomerListView,
-    CustomerDetailView,
+    CustomerCreateView,
+    CustomerUpdateView,
     CustomerUserListView,
     CustomerUserDetailView,
     CustomerUserInviteView,

--- a/astrosat_users/views/views_customers.py
+++ b/astrosat_users/views/views_customers.py
@@ -25,7 +25,6 @@ class IsAdminOrManager(BasePermission):
 
 
 class CannotDeleteSelf(BasePermission):
-
     def has_object_permission(self, request, view, obj):
         user = request.user
         if request.method == "DELETE":
@@ -71,11 +70,11 @@ class CustomerListView(CustomerViewMixin, generics.CreateAPIView):
 
 class CustomerDetailView(CustomerViewMixin, generics.RetrieveUpdateAPIView):
 
-    permission_classes = [IsAuthenticated, IsAdminOrManager]
-    serializer_class = CustomerSerializer
-
     lookup_field = "id"
     lookup_url_kwarg = "customer_id"
+
+    permission_classes = [IsAuthenticated, IsAdminOrManager]
+    serializer_class = CustomerSerializer
 
 
 class CustomerUserFilterSet(filters.FilterSet):
@@ -149,9 +148,7 @@ class CustomerUserListView(CustomerUserViewMixin, generics.ListCreateAPIView):
         return customer_user
 
 
-class CustomerUserDetailView(
-    CustomerUserViewMixin, generics.RetrieveUpdateDestroyAPIView
-):
+class CustomerUserDetailView(CustomerUserViewMixin, generics.RetrieveUpdateDestroyAPIView):
 
     permission_classes = [IsAuthenticated, IsAdminOrManager, CannotDeleteSelf]
     serializer_class = CustomerUserSerializer
@@ -165,16 +162,12 @@ class CustomerUserDetailView(
         adapter.send_mail(
             "astrosat_users/email/user_left_customer",
             user.email,
-            {
-                "user": user,
-                "customer": customer,
-            },
+            {"user": user, "customer": customer},
         )
         return destroyed_value
 
-class CustomerUserInviteView(
-    CustomerUserViewMixin, generics.GenericAPIView
-):
+
+class CustomerUserInviteView(CustomerUserViewMixin, generics.GenericAPIView):
     """
     A special view just for re-sending invitations.
     """

--- a/astrosat_users/views/views_customers.py
+++ b/astrosat_users/views/views_customers.py
@@ -33,13 +33,10 @@ class CannotDeleteSelf(BasePermission):
 
         return True
 
-class CustomerDetailView(generics.RetrieveUpdateAPIView):
 
-    permission_classes = [IsAuthenticated, IsAdminOrManager]
-    serializer_class = CustomerSerializer
+class CustomerViewMixin(object):
 
-    lookup_field = "id"
-    lookup_url_kwarg = "customer_id"
+    # DRY way of customizing object retrieval for the 2 views below
 
     @property
     def active_managers(self):
@@ -61,6 +58,24 @@ class CustomerDetailView(generics.RetrieveUpdateAPIView):
             return Customer.objects.none()
 
         return Customer.objects.multiple()
+
+
+class CustomerListView(CustomerViewMixin, generics.CreateAPIView):
+
+    lookup_field = "id"
+    lookup_url_kwarg = "customer_id"
+
+    permission_classes = [IsAuthenticated]
+    serializer_class = CustomerSerializer
+
+
+class CustomerDetailView(CustomerViewMixin, generics.RetrieveUpdateAPIView):
+
+    permission_classes = [IsAuthenticated, IsAdminOrManager]
+    serializer_class = CustomerSerializer
+
+    lookup_field = "id"
+    lookup_url_kwarg = "customer_id"
 
 
 class CustomerUserFilterSet(filters.FilterSet):

--- a/astrosat_users/views/views_customers.py
+++ b/astrosat_users/views/views_customers.py
@@ -59,7 +59,7 @@ class CustomerViewMixin(object):
         return Customer.objects.multiple()
 
 
-class CustomerListView(CustomerViewMixin, generics.CreateAPIView):
+class CustomerCreateView(CustomerViewMixin, generics.CreateAPIView):
 
     lookup_field = "id"
     lookup_url_kwarg = "customer_id"
@@ -68,7 +68,7 @@ class CustomerListView(CustomerViewMixin, generics.CreateAPIView):
     serializer_class = CustomerSerializer
 
 
-class CustomerDetailView(CustomerViewMixin, generics.RetrieveUpdateAPIView):
+class CustomerUpdateView(CustomerViewMixin, generics.RetrieveUpdateAPIView):
 
     lookup_field = "id"
     lookup_url_kwarg = "customer_id"

--- a/example/example/tests/test_customer_views.py
+++ b/example/example/tests/test_customer_views.py
@@ -15,7 +15,7 @@ from astrosat.tests.utils import *
 from astrosat_users.tests.factories import CustomerFactory
 from astrosat_users.tests.utils import *
 
-from astrosat_users.models import User
+from astrosat_users.models import User, Customer
 from astrosat_users.serializers import UserSerializerBasic
 
 from .factories import *
@@ -23,6 +23,24 @@ from .factories import *
 
 @pytest.mark.django_db
 class TestCustomerViews:
+
+    def test_create_customer(self, user, mock_storage):
+
+        customer_data = factory.build(dict, FACTORY_CLASS=CustomerFactory)
+        customer_data["type"] = customer_data.pop("customer_type")
+        customer_data.pop("logo")
+
+        _, key = create_auth_token(user)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Token {key}")
+        url = reverse("customers-list")
+
+        response = client.post(url, customer_data, format="json")
+        content = response.json()
+
+        assert status.is_success(response.status_code)
+        assert Customer.objects.count() == 1
+        assert str(Customer.objects.first().id) == content["id"]
 
     def test_get_customer(self, user, mock_storage):
 


### PR DESCRIPTION
Added a new view class to create `customers`.

Closes #83