### PR TITLE
feat(backend): return some user information from VerifyEmailView

### DIFF
--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -134,11 +134,12 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
         can be `None` here.
         """
         if self.is_api:
-            # TODO: ASK MARK WHAT THIS SHOULD BE?!?
+            # if the user registered via the API, then get the URL that the client should use
             path = app_settings.ACCOUNT_CONFIRM_EMAIL_CLIENT_URL.format(
                 key=emailconfirmation.key
             )
         else:
+            # otherwise, just use the builtin allauth view
             path = reverse("account_confirm_email", args=[emailconfirmation.key])
 
         if self.is_api and "HTTP_ORIGIN" in request.META:

--- a/astrosat_users/serializers/serializers_auth.py
+++ b/astrosat_users/serializers/serializers_auth.py
@@ -209,6 +209,7 @@ class VerifyEmailSerializer(ConsolidatedErrorsSerializerMixin, serializers.Seria
             )  # little hack here b/c I'm using a view outside a request
             emailconfirmation = view.get_object()
             data["confirmation"] = emailconfirmation
+            data["user"] = emailconfirmation.email_address.user
         except Exception:
             raise serializers.ValidationError("This is an invalid key.")
 

--- a/astrosat_users/views/views_auth.py
+++ b/astrosat_users/views/views_auth.py
@@ -251,7 +251,12 @@ class VerifyEmailView(RestAuthVerifyEmailView):
         confirmation = serializer.validated_data["confirmation"]
         confirmation.confirm(self.request)
 
-        return Response({"detail": _("ok")}, status=status.HTTP_200_OK)
+        response = {
+            "detail": _("ok"),
+            "user": UserSerializerLite(instance=serializer.validated_data["user"]).data,
+        }
+
+        return Response(response, status=status.HTTP_200_OK)
 
 
 class SendEmailVerificationView(GenericAPIView):

--- a/example/example/tests/test_registration.py
+++ b/example/example/tests/test_registration.py
@@ -180,6 +180,9 @@ class TestApiRegistration:
         assert status.is_success(response.status_code)
         assert user.is_verified is True
 
+        content = response.json()
+        assert user.username == content["user"]["username"]
+
     def test_resend_verify_email(self, user):
 
         assert user.is_verified is False


### PR DESCRIPTION
Return some user information (from `UserSerializerLite`) as part of the `VerifyEmailView` response.  This will allow the frontend to determine where to redirect after a successful user account activation.

Closes #92