### PR TITLE
chore(backend): fixed a missed error in PR #105

### DIFF
--- a/astrosat_users/serializers/serializers_auth.py
+++ b/astrosat_users/serializers/serializers_auth.py
@@ -22,6 +22,7 @@ from astrosat.serializers import ConsolidatedErrorsSerializerMixin
 
 from astrosat_users.conf import app_settings
 from astrosat_users.models import User
+from astrosat_users.models.models_users import UserRegistrationStageType
 from astrosat_users.utils import rest_decode_user_pk
 
 
@@ -167,7 +168,11 @@ class RegisterSerializer(ConsolidatedErrorsSerializerMixin, RestAuthRegisterSeri
 
     # add extra fields...
     accepted_terms = serializers.BooleanField()
-    registration_stage = serializers.CharField(default=None)
+    registration_stage = serializers.ChoiceField(
+        allow_null=True,
+        choices=UserRegistrationStageType.choices,
+        required=False,
+    )
 
     def validate_accepted_terms(self, value):
         if app_settings.ASTROSAT_USERS_REQUIRE_TERMS_ACCEPTANCE and not value:

--- a/astrosat_users/views/views_auth.py
+++ b/astrosat_users/views/views_auth.py
@@ -122,7 +122,7 @@ _register_schema = openapi.Schema(
             ),
             ("accepted_terms", openapi.Schema(type=openapi.TYPE_BOOLEAN)),
             (
-                "registration_status",
+                "registration_stage",
                 openapi.Schema(type=openapi.TYPE_STRING),
             ),
         )


### PR DESCRIPTION
The new `registration_stage` field was misspelt in the swagger documentation.  

More importantly, the `registration_stage` serializer field in the `RegisterSerializer` didn't correctly validate against choices
(this was b/c the `RegistrationSerializer` is _not_ a `ModelSerializer` where field attributes are set automatically based on the corresponding model fields).
