### PR TITLE
feat(backend): prevent duplicate cc messages

### DIFF
--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -306,8 +306,8 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
                 raise TypeError('"bcc" argument must be a list or tuple')
             self.bcc = list(bcc)
         msg = self.render_mail(template_prefix, email, context)
-        msg.cc = list(cc)
-        msg.bcc = list(bcc)
+        msg.cc = [address for address in bcc if address != email]
+        msg.bcc = [address for address in bcc if address != email]
         msg.send()
 
     def set_password(self, user, password):

--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -306,7 +306,7 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
                 raise TypeError('"bcc" argument must be a list or tuple')
             self.bcc = list(bcc)
         msg = self.render_mail(template_prefix, email, context)
-        msg.cc = [address for address in bcc if address != email]
+        msg.cc = [address for address in cc if address != email]
         msg.bcc = [address for address in bcc if address != email]
         msg.send()
 

--- a/astrosat_users/models/models_users.py
+++ b/astrosat_users/models/models_users.py
@@ -160,7 +160,7 @@ class User(AbstractUser):
 
         if customer:
             assert customer.users.filter(email=self.email).exists()
-            cc = customer.customer_users.managers().exclude(user=self).values_list("user__email", flat=True)
+            cc = customer.customer_users.managers().values_list("user__email", flat=True)
         else:
             cc = []
 


### PR DESCRIPTION
Remove the "to" address from the "cc" & "bcc" addresses in `adapter.send_mail` to prevent duplicate messages.  Also, removed the filter in `User.onboard` to remove the "to" address since it's done by default now.

This PR closes #114 

