### PR TITLE
123 invitation link

### DIFF
--- a/astrosat_users/adapters.py
+++ b/astrosat_users/adapters.py
@@ -127,6 +127,22 @@ class AccountAdapter(AdapterMixin, DefaultAccountAdapter):
 
         return user
 
+    def get_login_url(self, request):
+        """Constructs the login url.
+        """
+        if self.is_api:
+            # if the user registered via the API, then get the URL that the client should use
+            path = app_settings.ACCOUNT_LOGIN_CLIENT_URL
+        else:
+            # otherwise, just use the builtin allauth view
+            path = reverse("account_signup")
+        if self.is_api and "HTTP_ORIGIN" in request.META:
+            # request originates from a client on a different domain...
+            url = urljoin(request.META['HTTP_ORIGIN'], path)
+        else:
+            url = build_absolute_uri(request, path)
+        return url
+
     def get_email_confirmation_url(self, request, emailconfirmation):
         """Constructs the email confirmation (activation) url.
         Note that if you have architected your system such that email

--- a/astrosat_users/conf/settings.py
+++ b/astrosat_users/conf/settings.py
@@ -15,6 +15,9 @@ PROJECT_SLUG = getattr(settings, "PROJECT_SLUG", slugify(PROJECT_NAME))
 PROJECT_EMAIL = getattr(settings, "PROJECT_EMAIL", "{role}@astrosat.net")
 
 
+ACCOUNT_LOGIN_CLIENT_URL = getattr(
+    settings, "ACCOUNT_LOGIN_CLIENT_URL", "login/"
+)
 ACCOUNT_CONFIRM_EMAIL_CLIENT_URL = getattr(
     settings, "ACCOUNT_CONFIRM_EMAIL_CLIENT_URL", "verify-email/?key={key}"
 )

--- a/astrosat_users/models/models_customers.py
+++ b/astrosat_users/models/models_customers.py
@@ -197,7 +197,9 @@ class CustomerUser(models.Model):
             token_generator = kwargs.get("token_generator", adapter.default_token_generator)
             token_key = token_generator.make_token(user)
             url = adapter.get_password_confirmation_url(adapter.request, user, token_key)
-            context["password_reset_url"] = url
+        else:
+            url = adapter.get_login_url(adapter.request)
+        context["url"] = url
 
         if (
             allauth_app_settings.AUTHENTICATION_METHOD

--- a/astrosat_users/models/models_customers.py
+++ b/astrosat_users/models/models_customers.py
@@ -197,9 +197,10 @@ class CustomerUser(models.Model):
             token_generator = kwargs.get("token_generator", adapter.default_token_generator)
             token_key = token_generator.make_token(user)
             url = adapter.get_password_confirmation_url(adapter.request, user, token_key)
+            context["password_reset_url"] = url
         else:
             url = adapter.get_login_url(adapter.request)
-        context["url"] = url
+            context["login_url"] = url
 
         if (
             allauth_app_settings.AUTHENTICATION_METHOD

--- a/astrosat_users/templates/astrosat_users/email/invitation_message.txt
+++ b/astrosat_users/templates/astrosat_users/email/invitation_message.txt
@@ -11,11 +11,11 @@
 
     Hi, you have been invited to {{ customer.name }}.
 
-    {% if password_reset_url %}
+    {% if url %}
 
       Please follow the link below to create a User Account and Password.
 
-      {{ password_reset_url }}
+      {{ url }}
 
     {% endif %}
 

--- a/astrosat_users/templates/astrosat_users/email/invitation_message.txt
+++ b/astrosat_users/templates/astrosat_users/email/invitation_message.txt
@@ -11,11 +11,17 @@
 
     Hi, you have been invited to {{ customer.name }}.
 
-    {% if url %}
+    {% if password_reset_url %}
 
       Please follow the link below to create a User Account and Password.
 
-      {{ url }}
+      {{ password_reset_url }}
+
+    {% elif login_url %}
+
+      Please follow the link below to login.
+
+      {{ login_url }}
 
     {% endif %}
 

--- a/example/example/tests/test_customer_views.py
+++ b/example/example/tests/test_customer_views.py
@@ -491,11 +491,11 @@ class TestCustomerViews:
         assert new_content["invitation_date"] is not None
         assert new_content["user"]["change_password"] is True
 
-        RESET_PASSWORD_TEXT = "Please follow the link below to create a User Account and Password"
+        INVITATION_RESET_PASSWORD_TEXT = "Please follow the link below to create a User Account and Password"
 
         assert len(mail.outbox) == 2
-        assert RESET_PASSWORD_TEXT in mail.outbox[0].body
-        assert RESET_PASSWORD_TEXT in mail.outbox[1].body
+        assert INVITATION_RESET_PASSWORD_TEXT in mail.outbox[0].body
+        assert INVITATION_RESET_PASSWORD_TEXT in mail.outbox[1].body
 
     def test_resend_invitation_existing_customer_user(self, admin, user, mock_storage):
 
@@ -518,10 +518,12 @@ class TestCustomerViews:
         assert content["invitation_date"] is not None
         assert content["user"]["change_password"] is False
 
-        RESET_PASSWORD_TEXT = "Please follow the link below to create a User Account and Password"
+        INVITATION_RESET_PASSWORD_TEXT = "Please follow the link below to create a User Account and Password"
+        INVITATION_LOGIN_TEXT = "Please follow the link below to login"
 
         assert len(mail.outbox) == 1
-        assert RESET_PASSWORD_TEXT not in mail.outbox[0].body
+        assert INVITATION_RESET_PASSWORD_TEXT not in mail.outbox[0].body
+        assert INVITATION_LOGIN_TEXT in mail.outbox[0].body
 
     def test_onboard_customer_user(self, user, mock_storage):
 


### PR DESCRIPTION
A new or existing user can be invited to join a customer.  If the user is new, they must reset their password.  The reset password link is therefore included in the invitation email.  If the user is existing, there was no link invcluded.

This PR adds a simple login link to the invitation email in the case of existing users.

This PR closes #123

