### PR TITLE
feat(backend): new customer-users must explicitly accept terms

### DIFF
--- a/astrosat_users/serializers/serializers_customers.py
+++ b/astrosat_users/serializers/serializers_customers.py
@@ -66,7 +66,7 @@ class CustomerUserSerializer(serializers.ModelSerializer):
             default_password = User.objects.make_random_password()
             user_data.update({
                 "change_password": True,
-                "accepted_terms": True,
+                "accepted_terms": False,
                 "password1": default_password,
                 "password2": default_password,
             })

--- a/example/example/tests/test_customer_views.py
+++ b/example/example/tests/test_customer_views.py
@@ -338,6 +338,7 @@ class TestCustomerViews:
 
         assert customer.customer_users.count() == 1
         assert user.change_password is True
+        assert user.accepted_terms is False
         assert user.pk in customer.customer_users.values_list("user", flat=True)
         assert user.email == content["user"]["email"]
 


### PR DESCRIPTION
Ensuring that a newly-created customer_user has accept_terms set to False.  This means they will be required to accept the terms upon logging in.


