### PR TITLE
feat(backend): add user details to reset-password response

### DIFF
--- a/astrosat_users/views/views_auth.py
+++ b/astrosat_users/views/views_auth.py
@@ -240,7 +240,10 @@ class PasswordResetConfirmView(RestAuthPasswordResetConfirmView):
             user.save()
 
         return Response(
-            {"detail": _("Password has been reset with the new password.")}
+            {
+                "detail": _("Password has been reset with the new password."),
+                "user": UserSerializerLite(user).data
+            }
         )
 
 @method_decorator(

--- a/example/example/tests/test_passwords.py
+++ b/example/example/tests/test_passwords.py
@@ -176,4 +176,27 @@ class TestApiPassword:
         assert status.is_success(response.status_code)
         assert user.check_password(password)
 
-        pass
+    def test_password_verify_reset_returns_user(self, user):
+        """
+        tests that resetting the password returns UserSerializerLite
+        in the response
+        """
+
+        password = generate_password()
+        token_key = get_adapter().default_token_generator.make_token(user)
+        uid = rest_encode_user_pk(user)
+
+        url = reverse("rest_password_reset_confirm")
+        client = APIClient()
+
+        data = {
+            "new_password1": password,
+            "new_password2": password,
+            "uid": uid,
+            "token": token_key,
+        }
+
+        response = client.post(url, data)
+        content = response.json()
+        assert status.is_success(response.status_code)
+        assert content["user"]["email"] == user.email


### PR DESCRIPTION
Upon a successful password reset the output of UserSerializerLite is included in the Response.


