### PR TITLE
feat(backend): passed context to nested serializers

### DIFF
--- a/astrosat_users/serializers/serializers_users.py
+++ b/astrosat_users/serializers/serializers_users.py
@@ -85,6 +85,7 @@ class UserSerializerBasic(serializers.ModelSerializer):
             if profile:
                 profile_serializer_class = profile.get_serializer_class()
                 profiles_representation[profile_key] = profile_serializer_class(
+                    context=self.context
                 ).to_representation(profile)
 
         representation = super().to_representation(instance)
@@ -105,6 +106,7 @@ class UserSerializerBasic(serializers.ModelSerializer):
                 profile_class = PROFILES_REGISTRY[profile_key]
                 profile_serializer_class = profile_class.get_serializer_class()
                 profiles_internal_value[profile_key] = profile_serializer_class(
+                    context=self.context
                 ).to_internal_value(profile_data)
 
         internal_value = super().to_internal_value(data)
@@ -120,9 +122,10 @@ class UserSerializerBasic(serializers.ModelSerializer):
             for profile_key, profile_data in profiles_data.items():
                 profile_class = PROFILES_REGISTRY[profile_key]
                 profile_serializer_class = profile_class.get_serializer_class()
-                profile_serializer_class().update(
-                    getattr(instance, profile_key), profile_data
-                )
+                profile_serializer_class(
+                    context=self.context
+                ).update(getattr(instance, profile_key), profile_data)
+
         updated_instance = super().update(instance, validated_data)
 
         return updated_instance

--- a/astrosat_users/views/views_users.py
+++ b/astrosat_users/views/views_users.py
@@ -128,7 +128,7 @@ class UserFilterSet(filters.FilterSet):
         )  # yapf: disable
 
 
-class ListRetrieveViewSet(
+class ListRetrieveUpdateViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
@@ -144,7 +144,7 @@ class ListRetrieveViewSet(
     pass
 
 
-class UserViewSet(ListRetrieveViewSet):
+class UserViewSet(ListRetrieveUpdateViewSet):
 
     permission_classes = [IsAuthenticated, IsAdminOrSelf]
     serializer_class = UserSerializer

--- a/astrosat_users/views/views_users.py
+++ b/astrosat_users/views/views_users.py
@@ -17,7 +17,6 @@ from astrosat_users.models import User, UserRole, UserPermission
 from astrosat_users.models.models_users import UserRegistrationStageType
 from astrosat_users.serializers import UserSerializer
 
-
 #############
 # api views #
 #############
@@ -28,9 +27,7 @@ def UserRegistrationStagePermission(registration_stage_getter):
     This fn is a factory that returns a _dynamic_ DRF Permission.
     Only a request.user w/ a matching registration_stage is granted permission.
     """
-
     class _UserRegistrationStagePermission(BasePermission):
-
         def has_permission(self, request, view):
             if callable(registration_stage_getter):
                 registration_stage = registration_stage_getter(request)
@@ -61,12 +58,17 @@ class IsAdminOrSelf(BasePermission):
 class UserFilterSet(filters.FilterSet):
     class Meta:
         model = User
-        fields = ["is_active", "is_approved", "accepted_terms", "is_verified", "registration_stage"]
+        fields = [
+            "is_active", "is_approved", "accepted_terms", "is_verified",
+            "registration_stage"
+        ]
 
     is_active = BetterBooleanFilter()
     is_approved = BetterBooleanFilter()
     accepted_terms = BetterBooleanFilter()
-    registration_stage = filters.ChoiceFilter(choices=UserRegistrationStageType.choices)
+    registration_stage = filters.ChoiceFilter(
+        choices=UserRegistrationStageType.choices
+    )
     is_verified = filters.Filter(method="filter_is_verified")
 
     roles__any = filters.Filter(method="filter_roles_or")
@@ -82,7 +84,8 @@ class UserFilterSet(filters.FilterSet):
                 # Django cannot efficiently filter querysets by property
                 # so this basically recreates the logic of the @is_verified User property
                 queryset = queryset.filter(
-                    emailaddress__primary=True, emailaddress__verified=cleaned_value
+                    emailaddress__primary=True,
+                    emailaddress__verified=cleaned_value
                 )
         except ValidationError as e:
             raise APIException({name: e.messages})
@@ -90,27 +93,39 @@ class UserFilterSet(filters.FilterSet):
 
     def filter_roles_or(self, queryset, name, value):
         role_names = value.split(",")
-        return queryset.filter(roles__name__in=role_names).distinct()
+        return queryset.filter(
+            roles__name__in=role_names
+        ).distinct()  # yapf: disable
 
     def filter_roles_and(self, queryset, name, value):
         role_names = value.split(",")
         return (
-            queryset.filter(roles__name__in=role_names)
-            .annotate(num_roles=Count("roles"))
-            .filter(num_roles=len(role_names))
-        )
+            queryset.filter(
+                roles__name__in=role_names
+            ).annotate(
+                num_roles=Count("roles")
+            ).filter(
+                num_roles=len(role_names)
+            )
+        )  # yapf: disable
 
     def filter_permissions_or(self, queryset, name, value):
         permission_names = value.split(",")
-        return queryset.filter(roles__permissions__name__in=permission_names).distinct()
+        return queryset.filter(
+            roles__permissions__name__in=permission_names
+        ).distinct()  # yapf: disable
 
     def filter_permissions_and(self, queryset, name, value):
         permission_names = value.split(",")
         return (
-            queryset.filter(roles__permissions__name__in=permission_names)
-            .annotate(num_permissions=Count("roles__permissions"))
-            .filter(num_permissions=len(permission_names))
-        )
+            queryset.filter(
+                roles__permissions__name__in=permission_names
+            ).annotate(
+                num_permissions=Count("roles__permissions")
+            ).filter(
+                num_permissions=len(permission_names)
+            )
+        )  # yapf: disable
 
 
 class ListRetrieveViewSet(
@@ -133,7 +148,7 @@ class UserViewSet(ListRetrieveViewSet):
 
     permission_classes = [IsAuthenticated, IsAdminOrSelf]
     serializer_class = UserSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (filters.DjangoFilterBackend, )
     filterset_class = UserFilterSet
 
     queryset = User.objects.prefetch_related("roles", "roles__permissions")
@@ -144,11 +159,20 @@ class UserViewSet(ListRetrieveViewSet):
     def get_serializer_context(self):
         context = super().get_serializer_context()
 
+        # b/c of the convoluted nature of UserProfiles
+        # (which can have nested serializers w/in nested serializers)
+        # it is helpful to pass the user, from which we can access their profiles
+        # which can then be passed to any nested serializers as needed
+        if self.action in [
+            "retrieve", "update"
+        ]:  # TODO: WHAT TO DO ABOUT "list"?
+            context.update({"user": self.get_object()})
+
         # TODO: ADD SOME LOGIC HERE TO RESTRICT WHICH PROFILES WE CAN SERIALIZE
         # TODO: (NOT ALL USERS SHOULD MODIFY ALL PROFILES)
         managed_profiles = [profile_key for profile_key in User.PROFILE_KEYS]
-
         context.update({"managed_profiles": managed_profiles})
+
         return context
 
     def get_object(self, *args, **kwargs):


### PR DESCRIPTION
Added user to context of `UserSerializer` so that it is available to the corresponding `UserProfileSerializers`.  Just in case any of them need access to it for their own nested serializers.

This is a bit convoluted b/c of https://github.com/encode/django-rest-framework/issues/2555.

