### PR TITLE
chore(backend): no longer adding "user" to context of UserViewSet

### DIFF
--- a/astrosat_users/views/views_users.py
+++ b/astrosat_users/views/views_users.py
@@ -178,15 +178,6 @@ class UserViewSet(ListRetrieveUpdateViewSet):
     def get_serializer_context(self):
         context = super().get_serializer_context()
 
-        # b/c of the convoluted nature of UserProfiles
-        # (which can have nested serializers w/in nested serializers)
-        # it is helpful to pass the user, from which we can access their profiles
-        # which can then be passed to any nested serializers as needed
-        if self.action in [
-            "retrieve", "update"
-        ]:  # TODO: WHAT TO DO ABOUT "list"?
-            context.update({"user": self.get_object()})
-
         # TODO: ADD SOME LOGIC HERE TO RESTRICT WHICH PROFILES WE CAN SERIALIZE
         # TODO: (NOT ALL USERS SHOULD MODIFY ALL PROFILES)
         managed_profiles = [profile_key for profile_key in User.PROFILE_KEYS]


### PR DESCRIPTION
Although I still pass the parent context from `UserSerializers` to `UserProfileSerializers`, I no longer explicitly add "user" to that context.  It is just too complicated to ensure the context is always correct since the `UserSerializer` is used in so many different ways.

Instead, I split the serializer in **orbis** that was giving me so much trouble into 2 distinct classes:
* the `OrbisUserFeedbackRecordSerializer` which is used by the `OrbisUserFeedbackRecordView` - _which has a `ContextVariableDefault` field because it's used outside the `OrbisUserProfileSerializer`_
* and the `OrbisUserFeedbackRecordNestedSerializer` which is used by every other
view and so is never used w/out a parent `OrbisUserProfileSerializer` - _and therefore has no need of a `ContextVariableDefault` field_

