### PR TITLE
feat(backend): activate customer-user on login

### DIFF
--- a/astrosat_users/serializers/serializers_auth.py
+++ b/astrosat_users/serializers/serializers_auth.py
@@ -160,6 +160,7 @@ class PasswordResetConfirmSerializer(
 
         user = self.set_password_form.save()
 
+        # TODO: DELETE THIS? IT IS NOW DONE IN "VerifyEmailView"
         pending_customer_users_qs = user.customer_users.pending()
         if pending_customer_users_qs.exists():
             pending_customer_users_qs.update(customer_user_status="ACTIVE")

--- a/astrosat_users/views/views_auth.py
+++ b/astrosat_users/views/views_auth.py
@@ -309,6 +309,12 @@ class VerifyEmailView(RestAuthVerifyEmailView):
         confirmation = serializer.validated_data["confirmation"]
         confirmation.confirm(self.request)
 
+        # if I have successfuly verified the email address,
+        # then I should activate any pending customer_users
+        user = serializer.validated_data["user"]
+        pending_customer_users_qs = user.customer_users.pending()
+        pending_customer_users_qs.update(customer_user_status="ACTIVE")
+
         response = {
             "detail":
                 _("ok"),


### PR DESCRIPTION
When a user registers a customer and customer_user is now created.  When a user verifies their email address, that customer_user should now be activated.

